### PR TITLE
Delete cookies upon logout

### DIFF
--- a/src/main/java/com/coderscampus/SpringSecurityJWTDemo/security/SecurityConfig.java
+++ b/src/main/java/com/coderscampus/SpringSecurityJWTDemo/security/SecurityConfig.java
@@ -127,7 +127,7 @@ public class SecurityConfig {
                 .logout(logoutConfigurer -> {logoutConfigurer
                 	.logoutUrl("/logout")
                 	.logoutSuccessUrl("/signin")
-	                .deleteCookies("accessToken") // Cookies t÷o delete upon logout
+	                .deleteCookies("accessToken") // Cookies to delete upon logout
 //	                .deleteCookies("refreshToken") // Cookies to delete upon logout
                 	.invalidateHttpSession(true)
                 	.clearAuthentication(true);

--- a/src/main/java/com/coderscampus/SpringSecurityJWTDemo/security/SecurityConfig.java
+++ b/src/main/java/com/coderscampus/SpringSecurityJWTDemo/security/SecurityConfig.java
@@ -127,6 +127,8 @@ public class SecurityConfig {
                 .logout(logoutConfigurer -> {logoutConfigurer
                 	.logoutUrl("/logout")
                 	.logoutSuccessUrl("/signin")
+	                .deleteCookies("accessToken") // Cookies t÷o delete upon logout
+//	                .deleteCookies("refreshToken") // Cookies to delete upon logout
                 	.invalidateHttpSession(true)
                 	.clearAuthentication(true);
                 });


### PR DESCRIPTION
After user logs out, cookie is still in browser. Thus, logic created to remove cookie after user logs out.